### PR TITLE
Add the fs_msgs package with a `Test.msg`

### DIFF
--- a/src/fs_msgs/CMakeLists.txt
+++ b/src/fs_msgs/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.8)
+project(fs_msgs)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(dv_msgs REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  # set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  # set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/Test.msg"
+  DEPENDENCIES dv_msgs
+ )
+
+ament_export_dependencies(rosidl_default_runtime)
+ament_package()

--- a/src/fs_msgs/msg/Test.msg
+++ b/src/fs_msgs/msg/Test.msg
@@ -1,0 +1,2 @@
+dv_msgs/ObservationRangeBearing data
+dv_msgs/Cone[] cones

--- a/src/fs_msgs/package.xml
+++ b/src/fs_msgs/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>fs_msgs</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="geetsethi05@gmail.com">geet</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>dv_msgs</depend>
+
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Adds a custom message package called `fs_msgs` with a message named `Test` with the following schema:
```
Test {
  data ObservationRangeBearing
  cones Cone[]
}
```

Fixes #7 